### PR TITLE
pad NBD device with zeroes if data is not multiple of block size

### DIFF
--- a/buse.c
+++ b/buse.c
@@ -112,7 +112,9 @@ int buse_main(const char* dev_file, const struct buse_operations *aop, void *use
     return 1;
   }
 
-  err = ioctl(nbd, NBD_SET_SIZE, aop->size);
+  err = ioctl(nbd, NBD_SET_BLKSIZE, aop->block_size);
+  assert(err != -1);
+  err = ioctl(nbd, NBD_SET_SIZE_BLOCKS, aop->num_blocks);
   assert(err != -1);
   err = ioctl(nbd, NBD_CLEAR_SOCK);
   assert(err != -1);
@@ -175,7 +177,7 @@ int buse_main(const char* dev_file, const struct buse_operations *aop, void *use
     case NBD_CMD_READ:
       debug_print("Request for read of size %d\n", len);
       /* Fill with zero in case actual read is not implemented */
-      chunk = malloc(len);
+      chunk = calloc(1, len);
       if (aop->read) {
         reply.error = aop->read(chunk, len, from, userdata);
       } else {

--- a/buse.h
+++ b/buse.h
@@ -17,7 +17,8 @@ extern "C" {
     int (*flush)(void *userdata);
     int (*trim)(u_int64_t from, u_int32_t len, void *userdata);
 
-    u_int64_t size;
+    u_int32_t block_size;
+    u_int64_t num_blocks;
   };
 
   int buse_main(const char* dev_file, const struct buse_operations *bop, void *userdata);


### PR DESCRIPTION
Fixes #121.
