### PR TITLE
Switch to STD::ifstream for reading password files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,11 +15,22 @@ if( NOT CMAKE_BUILD_TYPE )
   set( CMAKE_BUILD_TYPE Release )
 endif( NOT CMAKE_BUILD_TYPE )
 
+set(STATIC_LINKING FALSE CACHE BOOL "Build a static binary?")
+if ( STATIC_LINKING )
+  MESSAGE("ZBackup static binary")
+  set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
+else ( STATIC_LINKING )
+  MESSAGE("ZBackup dynamic binary")
+endif ( STATIC_LINKING )
+
 find_package( ZLIB REQUIRED )
 include_directories( ${ZLIB_INCLUDE_DIRS} )
 
 find_package( OpenSSL REQUIRED )
 include_directories( ${OPENSSL_INCLUDE_DIR} )
+if( STATIC_LINKING )
+  set ( OPENSSL_LIBRARIES "${OPENSSL_LIBRARIES}" -ldl )
+endif(STATIC_LINKING)
 
 find_package( Protobuf REQUIRED )
 include_directories( ${PROTOBUF_INCLUDE_DIRS} )
@@ -64,6 +75,11 @@ if ( ZBACKUP_VERSION )
   MESSAGE("ZBackup version ${ZBACKUP_VERSION}")
 endif( ZBACKUP_VERSION )
 
+if( STATIC_LINKING )
+  set( CMAKE_EXE_LINKER_FLAGS "-static-libgcc -static-libstdc++" )
+  set ( LIBUNWIND_LIBRARIES )
+endif(STATIC_LINKING)
+
 set( sourceFiles
   appendallocator.cc
   backup_collector.cc
@@ -104,6 +120,7 @@ if ( WITH_BUSE )
     buse.c
   )
 endif()
+
 add_executable( zbackup ${sourceFiles} ${protoSrcs} ${protoHdrs} )
 if ( WITH_BUSE )
   target_compile_definitions( zbackup PRIVATE WITH_BUSE )
@@ -118,5 +135,9 @@ target_link_libraries( zbackup
   ${LIBLZO_LIBRARIES}
   ${LIBUNWIND_LIBRARIES}
 )
+
+#if( STATIC_LINKING )
+#  set_target_properties( zbackup PROPERTIES LINK_SEARCH_END_STATIC 1 )
+#endif(STATIC_LINKING)
 
 install( TARGETS zbackup DESTINATION bin )

--- a/zbackup.cc
+++ b/zbackup.cc
@@ -1,6 +1,9 @@
 // Copyright (c) 2012-2014 Konstantin Isakov <ikm@zbackup.org> and ZBackup contributors, see CONTRIBUTORS
 // Part of ZBackup. Licensed under GNU GPLv2 or later + OpenSSL, see LICENSE
 
+#include <fstream>
+#include <streambuf>
+
 #include "zutils.hh"
 #include "debug.hh"
 #include "version.hh"
@@ -32,18 +35,20 @@ int main( int argc, char *argv[] )
       {
         // Read the password
         char const * passwordFile = argv[ x + 1 ];
-        string passwordData;
         if ( passwordFile )
         {
-          File f( passwordFile, File::ReadOnly );
-          passwordData.resize( f.size() );
-          f.read( &passwordData[ 0 ], passwordData.size() );
+          // Read password from file/descriptor
+          std::ifstream passwordFileStream(passwordFile);
+          std::string passwordData((std::istreambuf_iterator<char>(passwordFileStream)),
+               std::istreambuf_iterator<char>());
 
           // If the password ends with \n, remove that last \n. Many editors will
           // add \n there even if a user doesn't want them to
           if ( !passwordData.empty() &&
                passwordData[ passwordData.size() - 1 ] == '\n' )
             passwordData.resize( passwordData.size() - 1 );
+
+          // Store new password
           passwords.push_back( passwordData );
         }
         ++x;


### PR DESCRIPTION
Current implementation of reading password files uses lseek() to fetch file size.
On new systems that causes ESPIPE when using file descriptors for passing passwords.
[ lseek(4, 0, SEEK_CUR)                   = -1 ESPIPE (Illegal seek) ]

Example of passing password using file descriptor from shell (bash):
$ read -s -p "Enter encryption password (echo off): " ZBPASS
$ zbackup --password-file <(echo "${ZBPASS}") init /home/user/backup

As a solution I sugest using STD::ifstream to read password files.

P.S.
The other commit is adding ability to build "mostly" static binary.
Only basic dependencies making the binary portable.